### PR TITLE
Fix ex00

### DIFF
--- a/ex00/Bureaucrat.cpp
+++ b/ex00/Bureaucrat.cpp
@@ -15,12 +15,14 @@ Bureaucrat::Bureaucrat(std::string const & name, int grade) : _name(name) {
 Bureaucrat::~Bureaucrat() {
 }
 
-Bureaucrat::Bureaucrat(Bureaucrat const & src) {
+Bureaucrat::Bureaucrat(Bureaucrat const & src) : _name(src._name) {
 	*this = src;
 }
 
 Bureaucrat &	Bureaucrat::operator=(Bureaucrat const & rhs) {
-	if (this != &rhs) {;}
+	if (this != &rhs) {
+		_grade = rhs._grade;
+	}
 	return *this;
 }
 

--- a/ex00/main.cpp
+++ b/ex00/main.cpp
@@ -23,7 +23,7 @@ void	test_bureaucrat(std::string const & name, int grade) {
 		std::cout << bureaucrat;
 	}
 	catch (const std::exception & exception) {
-		std::cerr << "##### An error occurred #####\n" <<
+		std::cout << "##### An exception occurred #####\n" <<
 			exception.what();
 	}
 }


### PR DESCRIPTION
Fixed copy constructor and assignment operator of Bureaucrat class
Substitute std::cerr to std::cout in the main.cpp